### PR TITLE
Fixes index page for Nightfall

### DIFF
--- a/app/destiny/Advisors.php
+++ b/app/destiny/Advisors.php
@@ -34,15 +34,19 @@ class Advisors extends Model
 
 	protected function gNightfall()
 	{
-		if ( ! $this->nightfallActivityHash)
+		$nightfall = $this->getNonMutatedProperty('nightfall');
+
+		if ($nightfall == null)
 		{
 			return null;
 		}
 
-		$definition = manifest()->activity($this->nightfallActivityHash);
+		$definition = manifest()->activity($nightfall['specificActivityHash']);
+		$skulls = manifest()->activity($nightfall['activityBundleHash']);
 
 		$activity = new Advisors\Activity($this, $definition, $this->nightfallResetDate);
-		$activity->addLevelRewards($definition);
+		$activity->addLevelRewards($skulls);
+		$activity->addActiveSkulls($skulls, $nightfall['tiers'][0]['skullIndexes']);
 
 		return $activity;
 	}

--- a/app/destiny/Advisors/Activity.php
+++ b/app/destiny/Advisors/Activity.php
@@ -32,4 +32,17 @@ class Activity extends ActivityDefinition
 		$this->rewards->put($definition->activityLevel, $level);
 
 	}
+
+	public function addActiveSkulls(ActivityDefinition $definition, array $skulls)
+	{
+		foreach ($definition->getNonMutatedProperty('skulls') as $key => $skull)
+		{
+			if (! in_array($key, $skulls))
+			{
+				unset($definition->properties['skulls'][$key]);
+			}
+		}
+
+		$this->skulls = $definition->getNonMutatedProperty('skulls');
+	}
 }

--- a/app/destiny/Model.php
+++ b/app/destiny/Model.php
@@ -110,6 +110,18 @@ abstract class Model implements JsonSerializable, ArrayableInterface, ArrayAcces
 		return $value;
 	}
 
+	protected function getNonMutatedProperty($key)
+	{
+		if (isset($this->cached[$key]))
+		{
+			return $this->cached[$key];
+		}
+
+		$value         = (isset($this->properties[$key]) ? $this->properties[$key] : null);
+
+		return $value;
+	}
+
 	protected function setProperty($key, $value)
 	{
 		$this->properties[$key] = $value;


### PR DESCRIPTION
- Adds method to get value w/ no mutator
- Adds method to remove skulls not used, cross referenced by activityBundleHash

Now this is my first time using this endpoint, since I've never built an application that needed this. It seems the initial values provided (`activityHash`) points to a generic Playlist like definition that has nothing but all skulls and the playlist.

Digging deeper you have the `nightfall` key which contains `activityBundleHash` and `specificActivityHash`. I couldn't find a way to directly access `nightfall['activtyBundleHash']` because `nightfall` triggers the mutator in `Model` for `gNightfall`. So I created `getNonMutatedProperty` so I could get this value without having the mutator take over. (A rename might be better here).

So now I had the correct activity, but wrong skulls. All were shown instead of right ones. Cross referencing the skull IDs provided by `specificActivityHash` with the manifest has mismatched IDs.

The correct skulls are in the initial dump of all skulls in the `activityBundleHash`. So I created `addActiveSkulls` which takes the values that the specific activity has and removes any not in that array from the originating `activityHash`. We then override these skulls into that activity.

Thus

![test](https://cloud.githubusercontent.com/assets/611784/12076717/4be01580-b17d-11e5-8e04-7705529a6594.png)

which fixes #1 
