### PR TITLE
Move to /summary endpoints

### DIFF
--- a/app/destiny/DestinyPlatform.php
+++ b/app/destiny/DestinyPlatform.php
@@ -31,7 +31,7 @@ class DestinyPlatform
 
 	public function account(Player $player)
 	{
-		return $this->request("destiny/$player->membershipType/account/$player->membershipId/", CACHE_DEFAULT);
+		return $this->request("destiny/$player->membershipType/account/$player->membershipId/summary/", CACHE_DEFAULT);
 	}
 
 	public function inventory(Character $character)
@@ -40,7 +40,7 @@ class DestinyPlatform
 		$membershipId = $character->membershipId;
 		$characterId = $character->characterId;
 
-		return $this->request("destiny/$membershipType/account/$membershipId/character/$characterId/inventory/", CACHE_DEFAULT);
+		return $this->request("destiny/$membershipType/account/$membershipId/character/$characterId/inventory/summary/", CACHE_DEFAULT);
 	}
 
 	public function progression(Character $character)

--- a/app/views/account.blade.php
+++ b/app/views/account.blade.php
@@ -46,26 +46,26 @@
 			<div class="tab-content">
 				<div class="inventory tab-pane active" role="tabpanel" id="inventory-<?=$i?>">
 					<div class="equipment panel">
-						@include('block/bucket', ['bucket' => $inventory->subclass])
-						@include('block/bucket', ['bucket' => $inventory->primaryWeapons])
-						@include('block/bucket', ['bucket' => $inventory->specialWeapons])
-						@include('block/bucket', ['bucket' => $inventory->heavyWeapons])
-						@include('block/bucket', ['bucket' => $inventory->ghost])
+						@include('block/bucket', ['item' => $inventory->subclass])
+						@include('block/bucket', ['item' => $inventory->primaryWeapons])
+						@include('block/bucket', ['item' => $inventory->specialWeapons])
+						@include('block/bucket', ['item' => $inventory->heavyWeapons])
+						@include('block/bucket', ['item' => $inventory->ghost])
 					</div>
 					<div class="equipment panel">
-						@include('block/bucket', ['bucket' => $inventory->head])
-						@include('block/bucket', ['bucket' => $inventory->arms])
-						@include('block/bucket', ['bucket' => $inventory->chest])
-						@include('block/bucket', ['bucket' => $inventory->legs])
-						@include('block/bucket', ['bucket' => $inventory->class])
-						@include('block/bucket', ['bucket' => $inventory->artifact])
+						@include('block/bucket', ['item' => $inventory->head])
+						@include('block/bucket', ['item' => $inventory->arms])
+						@include('block/bucket', ['item' => $inventory->chest])
+						@include('block/bucket', ['item' => $inventory->legs])
+						@include('block/bucket', ['item' => $inventory->class])
+						@include('block/bucket', ['item' => $inventory->artifact])
 					</div>
 					<div class="equipment panel">
-						@include('block/bucket', ['bucket' => $inventory->shader])
-						@include('block/bucket', ['bucket' => $inventory->emblem])
-						@include('block/bucket', ['bucket' => $inventory->vehicle])
-						@include('block/bucket', ['bucket' => $inventory->ship])
-						@include('block/bucket', ['bucket' => $inventory->emote])
+						@include('block/bucket', ['item' => $inventory->shader])
+						@include('block/bucket', ['item' => $inventory->emblem])
+						@include('block/bucket', ['item' => $inventory->vehicle])
+						@include('block/bucket', ['item' => $inventory->ship])
+						@include('block/bucket', ['item' => $inventory->emote])
 					</div>
 				</div>
 

--- a/app/views/block/bucket.blade.php
+++ b/app/views/block/bucket.blade.php
@@ -1,11 +1,7 @@
 <?php
 /**
- * @var \Destiny\Character\InventoryBucket $bucket
  * @var \Destiny\Character\InventoryItem $item
  */
-
-$item = $bucket->equipped;
-
 ?>
 
 @if($item)


### PR DESCRIPTION
- Adds /summary to account & inventory endpoints
- Hacks around Buckets, since each Bucket has 1 item (the equipped one)
- We don't need to search the buckets for equipped item, so just pass item
- fixes #12 

BEFORE:

```
destiny/1/account/4611686018430553461/?lc=en (670.09ms)
destiny/1/account/4611686018430553461/character/2305843009240817218/inventory/?lc=en (517.7ms)
destiny/1/account/4611686018430553461/character/2305843009241283261/inventory/?lc=en (515.7ms)
destiny/1/account/4611686018430553461/character/2305843009215679067/inventory/?lc=en (282.61ms)
```

So 670.09 + 517.7 + 515.7 + 282.61 = 1.986s

AFTER:

```
destiny/1/account/4611686018430553461/summary/?lc=en (299.62ms)
destiny/1/account/4611686018430553461/character/2305843009240817218/inventory/summary/?lc=en (242.3ms)
destiny/1/account/4611686018430553461/character/2305843009215679067/inventory/summary/?lc=en (253.01ms)
destiny/1/account/4611686018430553461/character/2305843009241283261/inventory/summary/?lc=en (266.03ms)
```

So 299.62 + 242.3 + 253.01 + 266.03 = 1.060s

So nearly cut the time in half it takes :) This is also on my local computer with some stupid Comcast ISP. Server results should be different. Getting faster and the Bungie team should be happy we aren't using those endpoints anymore.

No visual changes. Site acts just as before, just using different endpoints and leveraging manifest vs old endpoint.
