### PR TITLE
Add travis testing for PHP 5.4, 5.5, 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: php
+php:
+  - '5.6'
+  - '5.5'
+  - '5.4'
+install:
+  - ./build/ci-install.sh
+  - ./build/ci-compile.sh
+script:
+  - phpunit

--- a/build/ci-compile.sh
+++ b/build/ci-compile.sh
@@ -1,0 +1,4 @@
+#! /usr/bin/env bash
+set -e
+
+grunt build

--- a/build/ci-install.sh
+++ b/build/ci-install.sh
@@ -1,0 +1,12 @@
+#! /usr/bin/env bash
+set -e
+
+gem update --system
+gem install compass
+
+composer install
+php artisan key:generate
+
+npm install -g bower grunt-cli
+npm install
+bower install

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,9 @@
 
 [![Join the chat at https://gitter.im/TrackerNetwork/DestinyStatus](https://badges.gitter.im/TrackerNetwork/DestinyStatus.svg)](https://gitter.im/TrackerNetwork/DestinyStatus?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-### Community, please help us build this site! We are accepting all pull-requests that are in the spirit of the site.  For all other ideas and concepts, please create an issue, we can figure out something! 
+[![Build Status](https://travis-ci.org/TrackerNetwork/DestinyStatus.svg?branch=master)](https://travis-ci.org/TrackerNetwork/DestinyStatus)
+
+### Community, please help us build this site! We are accepting all pull-requests that are in the spirit of the site.  For all other ideas and concepts, please create an issue, we can figure out something!
 
 This project is based on the Laravel framework [v4.2].
 


### PR DESCRIPTION
- This commit will be fully functional once `travis init` is run from a repository owner's local CLI.
- This change enables simple support for testing across PHP 5.4, 5.5, 5.6 using the default phpunit.xml configuration.
  - At this time, no tests are defined.
