### PR TITLE
Adds checklist for Nightfall and Daily PVE

### DIFF
--- a/app/destiny/Character.php
+++ b/app/destiny/Character.php
@@ -213,6 +213,11 @@ class Character extends Model
 		return $this->activities->weekly;
 	}
 
+	protected function gDailyAndNightfall()
+	{
+		return $this->activities->dailyAndNightfall;
+	}
+
 	protected function gWeeklyStrikes()
 	{
 		return $this->activities->weeklyStrikes;

--- a/app/destiny/Character/ActivityCollection.php
+++ b/app/destiny/Character/ActivityCollection.php
@@ -19,7 +19,12 @@ class ActivityCollection extends Collection
 	 */
 	public $dateActivityStarted;
 
-	public function __construct(Character $character, array $activities, array $raids, array $arenas, array $stats)
+	/**
+	 * @var \Destiny\Advisors\Activity
+	 */
+	public $dailyChapter;
+
+	public function __construct(Character $character, array $activities, array $pves, array $stats)
 	{
 		$this->character = $character;
 		$this->dateActivityStarted = carbon($activities['dateActivityStarted']);
@@ -27,49 +32,80 @@ class ActivityCollection extends Collection
 		$lastReset = last_weekly();
 		$nextReset = next_weekly();
 
-		// raid completion status
+		// raid, arena and nightfall completion status
 		$raidsCompleted = [];
-		foreach ($raids as $raid)
+		$arenasCompleted = [];
+		$activitiesCompleted = [];
+
+		// need advisors to identify daily
+		$this->dailyChapter = destiny()->advisors()->daily;
+
+		foreach($pves as $pve)
 		{
-			$activityHash  = (string) $raid['activityDetails']['referenceId'];
-			$activity      = manifest()->activity($activityHash);
-			$activityId    = sha1($activity->activityName);
-			$activityLevel = $activity->activityLevel;
+			$activityHash   = (string) $pve['activityDetails']['referenceId'];
+			$activity       = manifest()->activity($activityHash);
+			$activityId     = sha1($activity->activityName);
+			$activityType   = $activity->activityType;
+			$completed      = (bool) array_get($pve, 'values.completed.basic.value', false);
+			$date           = carbon($pve['period']);
 
-			$completed = (bool) array_get($raid, 'values.completed.basic.value', false);
-			$date = carbon($raid['period']);
-
-			if ( ! isset($raidsCompleted[$activityId]))
+			if ($activityType->isRaid())
 			{
-				$raidsCompleted[$activityId] = null;
-			}
+				$activityLevel = $activity->activityLevel;
 
-			if ($completed && $date > $lastReset && $date < $nextReset)
-			{
-				if ($activityLevel > $raidsCompleted[$activityId])
+				if ( ! isset($raidsCompleted[$activityId]))
 				{
-					$raidsCompleted[$activityId] = $activityLevel;
+					$raidsCompleted[$activityId] = null;
+				}
+
+				if ($completed && $date > $lastReset && $date < $nextReset)
+				{
+					if ($activityLevel > $raidsCompleted[$activityId])
+					{
+						$raidsCompleted[$activityId] = $activityLevel;
+					}
 				}
 			}
-		}
 
-		// arena completion status
-		$arenasCompleted = [];
-		foreach ($arenas as $arena)
-		{
-			$activityHash  = (string) $arena['activityDetails']['referenceId'];
-
-			$completed = (bool) array_get($arena, 'values.completed.basic.value', false);
-			$date = carbon($arena['period']);
-
-			if ( ! array_key_exists($activityHash, $arenasCompleted))
+			if ($activityType->isArena())
 			{
-				$arenasCompleted[$activityHash] = false;
+				if ( ! array_key_exists($activityHash, $arenasCompleted))
+				{
+					$arenasCompleted[$activityHash] = false;
+				}
+
+				if ($completed && $date > $lastReset && $date < $nextReset)
+				{
+					$arenasCompleted[$activityHash] = $completed;
+				}
 			}
 
-			if ($completed && $date > $lastReset && $date < $nextReset)
+			if ($activityType->isNightfall())
 			{
-				$arenasCompleted[$activityHash] = $completed;
+				$nightfallHash = $activity->activityType->activityTypeHash;
+
+				if ( ! array_key_exists($nightfallHash, $activitiesCompleted))
+				{
+					$activitiesCompleted[$nightfallHash] = false;
+				}
+
+				if ($completed && $date > $lastReset && $date < $nextReset)
+				{
+					$activitiesCompleted[$nightfallHash] = $completed;
+				}
+			}
+
+			if ($activityHash == $this->dailyChapter->activityHash)
+			{
+				if ( ! array_key_exists($activityHash, $activitiesCompleted))
+				{
+					$activitiesCompleted[$activityHash] = false;
+				}
+
+				if ($completed && $date > last_daily() && $date < next_daily())
+				{
+					$activitiesCompleted[$activityHash] = $completed;
+				}
 			}
 		}
 
@@ -90,11 +126,9 @@ class ActivityCollection extends Collection
 			$activity   = new Activity($character, $activity, $activityStats);
 			$activityId = sha1($activity->activityName);
 
-			if ($activity->isCompleted && ($activity->isWeekly() || $activity->isDaily()))
+			if ($activity->isCompleted && $activity->isWeekly())
 			{
-				$lastReset = ($activity->isWeekly() ? last_weekly() : last_daily());
-
-				$activity->isCompleted = ($character->dateLastPlayed > $lastReset);
+				$activity->isCompleted = ($character->dateLastPlayed > last_weekly());
 			}
 
 			$this->put($activityHash, $activity);
@@ -118,6 +152,16 @@ class ActivityCollection extends Collection
 			if ($activity->isArena())
 			{
 				$activity->isCompleted = array_get($arenasCompleted, $activityHash, false);
+			}
+
+			if ($activity->isNightfall())
+			{
+				$activity->isCompleted = array_get($activitiesCompleted, $activity->activityType->activityTypeHash, false);
+			}
+
+			if ($activityHash == $this->dailyChapter->activityHash)
+			{
+				$activity->isCompleted = array_get($activitiesCompleted, $activityHash, false);
 			}
 		}
 	}
@@ -158,6 +202,21 @@ class ActivityCollection extends Collection
 		foreach ($this as $k => $activity)
 		{
 			if ($activity->isWeeklyHeroic() || $activity->isNightfall())
+			{
+				$items[$k] = $activity;
+			}
+		}
+
+		return $items;
+	}
+
+	protected function gDailyAndNightfall()
+	{
+		$items = [];
+
+		foreach($this as $k => $activity)
+		{
+			if ($activity->activityHash == $this->dailyChapter->activityHash || $activity->isNightfall())
 			{
 				$items[$k] = $activity;
 			}

--- a/app/destiny/Definitions/ActivityType.php
+++ b/app/destiny/Definitions/ActivityType.php
@@ -40,6 +40,7 @@ class ActivityType extends Definition
 
 	public function isDaily()
 	{
+		// cannot be trusted anymore. Daily PVE Events do not have this ActivityType
 		return $this->identifier == 'ACTIVITY_TYPE_STORY_FEATURED';
 	}
 

--- a/app/destiny/Destiny.php
+++ b/app/destiny/Destiny.php
@@ -74,9 +74,10 @@ class Destiny
 			$requests["$cid.activitystats"] = $this->platform->statsActivityAggregated($character);
 			$requests["$cid.inventory"]     = $this->platform->inventory($character);
 			$requests["$cid.progression"]   = $this->platform->progression($character);
-			$requests["$cid.raids"]         = $this->platform->raids($character);
-			$requests["$cid.arenas"]        = $this->platform->arenas($character);
+			$requests["$cid.pve"]			= $this->platform->pve($character);
 			#$requests["$cid.stats"]         = $this->platform->statsCharacter($character);
+			#$requests["$cid.raids"]         = $this->platform->raids($character);
+			#$requests["$cid.arenas"]        = $this->platform->arenas($character);
 		}
 
 		$results = $this->client->request($requests);
@@ -89,10 +90,11 @@ class Destiny
 			$activityStats = array_get($results["$cid.activitystats"], 'data.activities', []);
 			$inventory     = array_get($results["$cid.inventory"],     'data', []);
 			$progression   = array_get($results["$cid.progression"],   'data', []);
-			$raids         = array_get($results["$cid.raids"],         'data.activities', []);
-			$arenas        = array_get($results["$cid.arenas"],        'data.activities', []);
+			$pve           = array_get($results["$cid.pve"],		   'data.activities', []);
+			#$raids         = array_get($results["$cid.raids"],         'data.activities', []);
+			#$arenas        = array_get($results["$cid.arenas"],        'data.activities', []);
 
-			$character->activities   = new ActivityCollection($character, $activities, $raids, $arenas, $activityStats);
+			$character->activities   = new ActivityCollection($character, $activities, $pve, $activityStats);
 			$character->inventory    = new Inventory($character, $inventory);
 			$character->progression  = new ProgressionCollection($character, $progression);
 			#$character->statistics   = new CharacterStatistics($character, $results["$cid.stats"]);

--- a/app/destiny/DestinyPlatform.php
+++ b/app/destiny/DestinyPlatform.php
@@ -80,6 +80,11 @@ class DestinyPlatform
 		return $this->statsActivityHistory($character, "ArenaChallenge");
 	}
 
+	public function pve(Character $character)
+	{
+		return $this->statsActivityHistory($character, "AllPvE", 0, 35);
+	}
+
 	public function statsAccount(Player $player)
 	{
 		return $this->request("destiny/stats/account/$player->membershipType/$player->membershipId/", ['groups' => ['General']], CACHE_DEFAULT);

--- a/app/views/account.blade.php
+++ b/app/views/account.blade.php
@@ -104,6 +104,14 @@
 						@include('block/weekly', ['progression' => $character->progression->weeklyCrucible])
 					</div> */ ?>
 
+					@if(count($character->dailyAndNightfall))
+					<div class="panel-heading">Activities</div>
+					<div class="activities panel">
+						@foreach($character->dailyAndNightfall as $activity)
+								@include('block/activity', ['activity' => $activity])
+							@endforeach
+						</div>
+					@endif
 					@if(count($character->weeklyRaids))
 					<div class="panel-heading">Raids</div>
 					<div class="activities panel">

--- a/app/views/account.blade.php
+++ b/app/views/account.blade.php
@@ -39,7 +39,7 @@
 			<ul class="nav nav-pills nav-justified" role="tablist">
 				<li class="active"><a href="#inventory-<?=$i?>" role="tab" data-toggle="tab" data-group="<?=$i?>">Items</a></li>
 				<li><a href="#progressions-<?=$i?>" role="tab" data-toggle="tab" data-group="<?=$i?>">Reputation</a></li>
-				<li><a href="#weekly-<?=$i?>" role="tab" data-toggle="tab" data-group="<?=$i?>">Weekly</a></li>
+				<li><a href="#weekly-<?=$i?>" role="tab" data-toggle="tab" data-group="<?=$i?>">Checklist</a></li>
 				<li><a href="#stats-<?=$i?>" role="tab" data-toggle="tab" data-group="<?=$i?>">Stats</a></li>
 			</ul>
 
@@ -108,9 +108,9 @@
 					<div class="panel-heading">Activities</div>
 					<div class="activities panel">
 						@foreach($character->dailyAndNightfall as $activity)
-								@include('block/activity', ['activity' => $activity])
-							@endforeach
-						</div>
+							@include('block/activity', ['activity' => $activity])
+						@endforeach
+					</div>
 					@endif
 					@if(count($character->weeklyRaids))
 					<div class="panel-heading">Raids</div>


### PR DESCRIPTION
- removes arena/raids calls (6) in favor of 3 pve calls (net -3 calls)
- manually checks advisor hash of daily instead of ActivityType
- comments out old calls vs removing
- adds nightfall/daily to weekly tab
- fixes #3 

Hold off on merging this yet. I need to check 3 things
 1) ~~~That `PoE` games show up in `AllPvE`. I haven't done a `PoE` in ages, so need to do one.~~~
 2) ~~~Lemme see if the daily works tomorrow after reset to ensure my code for getting daily is right~~~

![test2](https://cloud.githubusercontent.com/assets/611784/12131450/516a44c8-b3d8-11e5-8a05-fc4be0b7b283.png)
