### PR TITLE
Fixes isolated Grimoire issue

### DIFF
--- a/app/destiny/Grimoire/StatisticCollection.php
+++ b/app/destiny/Grimoire/StatisticCollection.php
@@ -15,7 +15,7 @@ class StatisticCollection extends Collection
 			{
 				$statistic = new Statistic($card, $properties);
 
-				if ($statistic->value)
+				if ($statistic->value || $statistic->hasRanks())
 				{
 					$this->items[$statistic->statNumber] = $statistic;
 				}


### PR DESCRIPTION
If you have a 0 value in the `RankCollection` field but already have points in it, the `RankCollection` fails the `->value` check, because it is a null. If this `RankCollection` exists (Like the main value field for any multi-tiered grimoire card), lets include it.

fixes #26 

![issue](https://cloud.githubusercontent.com/assets/611784/12199644/46e74650-b5df-11e5-8ac0-1286cc5af0df.png)

As you can see, we correctly show the Rumble Grimoire even though he has 0 wins.
