### PR TITLE
Assorted changes

### DIFF
--- a/app/destiny/Character/InventoryItem.php
+++ b/app/destiny/Character/InventoryItem.php
@@ -52,11 +52,6 @@ class InventoryItem extends InventoryItemDefinition
 	];
 
 	protected $classified = [
-		'4097026463' => [
-			'itemName' => 'No Time To Explain',
-			'itemTypeName' => 'Pulse Rifle',
-			'tierTypeName' => 'Exotic',
-		],
 	];
 
 	/**

--- a/app/destiny/Character/InventoryItem.php
+++ b/app/destiny/Character/InventoryItem.php
@@ -152,12 +152,12 @@ class InventoryItem extends InventoryItemDefinition
 
 	protected function gDamageTypeName()
 	{
-		return array_get($this->damageTypes, "$this->damageType.name");
+		return array_get($this->damageTypes, "$this->damageType.name", "Kinetic");
 	}
 
 	protected function gDamageTypeIcon()
 	{
-		return array_get($this->damageTypes, "$this->damageType.icon");
+		return array_get($this->damageTypes, "$this->damageType.icon", "/img/kinetic.png");
 	}
 
 	protected function gLightStat()

--- a/app/destiny/Grimoire.php
+++ b/app/destiny/Grimoire.php
@@ -66,12 +66,7 @@ class Grimoire extends Model
 			{
 				foreach ($page->cardBriefs as $card)
 				{
-					$skip = ($this->player->platform != 'psn' && $card->isPlaystationExclusive());
-
-					if ( ! $skip)
-					{
 						$collection->put($card->cardId, $card);
-					}
 				}
 			}
 		}


### PR DESCRIPTION
- No Time To Explain isn't classified anymore
- Return Kinetic if no damage time found (fixes #28)
- Show PSN exclusives with little icon to say it, isn't of hiding grimoire cards completely.
