### PR TITLE
add unit test for #32

### DIFF
--- a/app/tests/Issue32Test.php
+++ b/app/tests/Issue32Test.php
@@ -1,0 +1,19 @@
+<?php
+
+class Issue32Test extends \TestCase {
+
+    public function testUnicodeTransliteration()
+    {
+        $ir = 'Ir Yût, the Deathsinger';
+        $this->assertEquals('ir-yut-the-deathsinger', slug($ir));
+
+        $alzok = 'Alzok Däl, Gornuk Däl, Zyrok Däl';
+        $this->assertEquals('alzok-dal-gornuk-dal-zyrok-dal', slug($alzok));
+
+        $balwur = 'Balwûr';
+        $this->assertEquals('balwur', slug($balwur));
+
+        $primus = 'Primus Ta\'aun';
+        $this->assertEquals('primus-taaun', slug($primus));
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
 			"app/commands",
 			"app/controllers",
 			"app/database/migrations",
-			"app/database/seeds"
+			"app/database/seeds",
+			"app/tests/TestCase.php"
 		],
 		"psr-4": {
 			"Destiny\\": "app/destiny"


### PR DESCRIPTION
I added a unit test for #32 to debug it, but everything worked fine. I assume that code is the same `slug` code running on DTR, so must be an environment or config issue.

I noticed here that the newest iconv library has issue with `//ignore` with workaround here - http://php.net/manual/en/function.iconv.php#108643
