### PR TITLE
Add PVP Weekly/Daily items to index

### DIFF
--- a/app/destiny/Advisors.php
+++ b/app/destiny/Advisors.php
@@ -4,16 +4,22 @@ use Destiny\Advisors\ArenaCollection;
 
 /**
  * @property string $nightfallActivityHash
+ * @property string $dailyCrucibleHash
  * @property array $heroicStrikeHashes
  * @property array $dailyChapterHashes
+ * @property array $weeklyCrucible
  * @property \Carbon\Carbon $nightfallResetDate
  * @property \Carbon\Carbon $heroicStrikeResetDate
  * @property \Carbon\Carbon $dailyChapterResetDate
+ * @property \Carbon\Carbon $dailyCrucibleResetDate
  *
  * @property \Destiny\Advisors\Activity $nightfall
  * @property \Destiny\Advisors\Activity $heroic
  * @property \Destiny\Advisors\Activity $daily
+ * @property \Destiny\Advisors\Activity $dailyCrucible
  * @property \Destiny\Advisors\Event[] $events
+ *
+ * @property ArenaCollection $arena
  */
 class Advisors extends Model
 {
@@ -28,6 +34,11 @@ class Advisors extends Model
 	}
 
 	protected function gDailyChapterResetDate($value)
+	{
+		return carbon($value);
+	}
+
+	protected function gDailyCrucibleResetDate($value)
 	{
 		return carbon($value);
 	}
@@ -91,6 +102,30 @@ class Advisors extends Model
 		{
 			$activity->addLevelRewards(manifest()->activity($activityHash));
 		}
+
+		return $activity;
+	}
+
+	protected function gWeeklyCrucible()
+	{
+		$activityHash = $this->properties['weeklyCrucible'][0]['activityBundleHash'];
+
+		$activity = new Advisors\Activity($this, manifest()->activity($activityHash), $this->nightfallResetDate);
+		$activity->addLevelRewards(manifest()->activity($activityHash));
+
+		// set image manually to remove placeholder
+		$activity->pgcrImage = $this->properties['weeklyCrucible'][0]['image'];
+
+		return $activity;
+	}
+
+	protected function gDailyCrucible()
+	{
+		$activity = new Advisors\Activity($this, manifest()->activity($this->dailyCrucibleHash), $this->dailyCrucibleResetDate);
+		$activity->addLevelRewards(manifest()->activity($this->dailyCrucibleHash));
+
+		// set image manually to remove placeholder
+		$activity->pgcrImage = $this->properties['dailyCrucible']['image'];
 
 		return $activity;
 	}

--- a/app/views/block/advisor.blade.php
+++ b/app/views/block/advisor.blade.php
@@ -30,7 +30,13 @@ if ($advisor instanceof \Destiny\Advisors\Activity): $id = 'activity-'.$advisor-
 	<div role="tabpanel" class="rewards levels">
 		<ul class="nav nav-pills" role="tablist">
 			<?php $i = 0; foreach($advisor->rewards as $activity): $i++; ?>
-			<li class="<?= ($i == 1 ? 'active' : '') ?>"><a href="#<?= $id . $i ?>" role="tab" data-toggle="tab">Level <?= $activity->level ?></a></li>
+			<li class="<?= ($i == 1 ? 'active' : '') ?>"><a href="#<?= $id . $i ?>" role="tab" data-toggle="tab">
+				@if ($activity->level > 1)
+					Level <?= $activity->level ?>
+				@else
+					Rewards
+				@endif
+			</a></li>
 			<?php endforeach; ?>
 		</ul>
 

--- a/app/views/index.blade.php
+++ b/app/views/index.blade.php
@@ -31,21 +31,35 @@
 			@include('block/advisor', ['advisor' => $advisors->nightfall])
 		</div>
 		@endif
-		@if( App::environment('production'))
-		<div class="col-md-4">
-			<div style="margin-top:50px;">
-			<script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
-			<!-- Destiny Status Box -->
-			<ins class="adsbygoogle"
-			     style="display:inline-block;width:300px;height:250px"
-			     data-ad-client="ca-pub-6063092344832731"
-			     data-ad-slot="1557454912"></ins>
-			<script>
-			(adsbygoogle = window.adsbygoogle || []).push({});
-			</script>
+	</div>
+	<div class="activities row">
+		@if($advisors->dailyCrucible)
+			<div class="col-md-4 daily">
+				<h3>Daily PVP Mission</h3>
+				@include('block/advisor', ['advisor' => $advisors->dailyCrucible])
 			</div>
-		</div>
 		@endif
+		@if($advisors->weeklyCrucible)
+			<div class="col-md-4 daily">
+				<h3>Weekly PVP Mission</h3>
+				@include('block/advisor', ['advisor' => $advisors->weeklyCrucible])
+			</div>
+		@endif
+        @if( App::environment('production'))
+            <div class="col-md-4">
+                <div style="margin-top:50px;">
+                    <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+                    <!-- Destiny Status Box -->
+                    <ins class="adsbygoogle"
+                         style="display:inline-block;width:300px;height:250px"
+                         data-ad-client="ca-pub-6063092344832731"
+                         data-ad-slot="1557454912"></ins>
+                    <script>
+                        (adsbygoogle = window.adsbygoogle || []).push({});
+                    </script>
+                </div>
+            </div>
+        @endif
 	</div>
 
 	<h3>Prison of Elders</h3>

--- a/app/views/index.blade.php
+++ b/app/views/index.blade.php
@@ -35,13 +35,13 @@
 	<div class="activities row">
 		@if($advisors->dailyCrucible)
 			<div class="col-md-4 daily">
-				<h3>Daily PVP Mission</h3>
+				<h3>Daily PVP Activity</h3>
 				@include('block/advisor', ['advisor' => $advisors->dailyCrucible])
 			</div>
 		@endif
 		@if($advisors->weeklyCrucible)
 			<div class="col-md-4 daily">
-				<h3>Weekly PVP Mission</h3>
+				<h3>Weekly PVP Activity</h3>
 				@include('block/advisor', ['advisor' => $advisors->weeklyCrucible])
 			</div>
 		@endif


### PR DESCRIPTION
Due to more and more activities that people want, which will probably increase with ROI. I've added the daily/weekly PVP activities to index. I've also moved the box google ad to the PVP row of activities. This means we now go

```
EVENTS
DAILY PVE | WEEKLY PVE | NOTHING
DAILY PVP | WEEKLY PVP | AD
POE 32    | POE 34     | POE 35
```

The "Weekly Bonus Remaining" is a bit strange and doesn't belong. I can probably hide that index of RewardIndexes if we deem its too confusing to keep.

![screen shot 2016-08-26 at 2 21 59 pm](https://cloud.githubusercontent.com/assets/611784/18016117/a3227bbe-6b98-11e6-98fe-f3795aa1b827.png)

Still need to figure out how to display the remaining boxes (if interested, like bounties/xur inventory/test weapons).
