### PR TITLE
Added PS4 exclusive ghost fragments in crucible maps.

### DIFF
--- a/destiny/Grimoire/Card.php
+++ b/destiny/Grimoire/Card.php
@@ -74,6 +74,8 @@ class Card extends Model
 		'700590' => 'Theosyion, the Restorative Mind',
 		'701370' => 'Ghost Fragment: Vex 5',
 		'790010' => 'Zen Meteor',
+		'800110' => 'Ghost Fragment: Icarus',
+		'800131' => 'Ghost Fragment: Sector 618',
 		'800448' => 'Icarus - Languid Sea, Mercury'
 	];
 


### PR DESCRIPTION
Ghost Fragment: Icarus and Ghost Fragment: Sector 618 are unobtainable on xbox.
