### PR TITLE
Removed previously bugged cards

### DIFF
--- a/destiny/Grimoire/Card.php
+++ b/destiny/Grimoire/Card.php
@@ -39,10 +39,6 @@ class Card extends Model
 	 * @var array
 	 */
 	protected $bugged = [
-		'790020', // Chroma
-		'800312', // Khvostov Field Manual, pg. 90
-		'800407', // Lady Efideet
-		'800439', // Beauty in Destruction
 	];
 
 	/**


### PR DESCRIPTION
These cards have been allegedly fixed by Bungie in today's update (source: https://www.bungie.net/en/News/Article/45464 and https://www.bungie.net/en/Forums/Post/213318340). I would keep the bugged array just in case some of those fixes fail or other cards are reported as bugged by the community.